### PR TITLE
Update Setup-B2CMultiTenant.ps1 to set the correct AAD-Common app ID

### DIFF
--- a/Scripts/MultiTenant/Setup-B2CMultiTenant.ps1
+++ b/Scripts/MultiTenant/Setup-B2CMultiTenant.ps1
@@ -427,7 +427,7 @@ $aadCommonPwd = New-AzureADApplicationPasswordCredential -ObjectId $aadCommon.ob
 $appCommonSP = New-AzureADServicePrincipal -AppId $aadCommon.appId -AccountEnabled $true
 
 UploadIEFSymKey -keysetName "AADCommonSecret" -value $aadCommonPwd.Value
-$iefConf.AADCommonAppId = ("https://{0}/tenant" -f $aadCommon.appId)
+$iefConf.AADCommonAppId = $aadCommon.appId
 $iefConf.AADCommonSecret = "B2C_1A_AADCommonSecret"
 out-file -FilePath $iefConfPath -inputobject (ConvertTo-Json $iefConf)
 


### PR DESCRIPTION
This PR is to fix the AADSTS700016 error mentioned in [issue 10](https://github.com/mrochon/b2csamples/issues/10), where upon attempting to sign in an error is returned, indicating the application with ID `https://{guid}/tenant` was not found in the directory. 

The GUID in the application ID mentioned in the error matches the AADCommon application registered during setup. If you download the `B2C_1A_{PolicyPrefix}Extensions` XML file, you will find the `https://{guid}/tenant` URL in the `comonaad` claims provider's `client_id` property. If you update `client_id` to the value of the AADCommon app ID (just the guid, not a URI) and re-upload the policy, tenant creation and sign-in work as expected.

The `commonaad` claims provider has `client_id` set to `{AADCommonAppId}`, which is pulled from `conf.json`. whose value is set in `Setup-B2CMultiTenant.ps1` by formatting the application ID into the URI reported in the AADSTS700016 error.

Changing this line to emit only the application ID resolves the issue.